### PR TITLE
add: add API key middleware

### DIFF
--- a/src/controllers/userCtrl.go
+++ b/src/controllers/userCtrl.go
@@ -5,7 +5,6 @@ import (
 	"API/security"
 	services "API/services/users"
 	"context"
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/huandu/facebook/v2"
 	"google.golang.org/api/idtoken"
@@ -249,27 +248,4 @@ func DeleteUser(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"data": true})
-}
-
-func CsrfMiddleware(c *gin.Context) {
-	csrfToken := c.Request.Header.Get(HandsAppCsrfToken)
-	jwtCookie, cookieErr := c.Request.Cookie(HandsAppSession)
-
-	if cookieErr != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprint("Cookie: ", HandsAppSession, " is not present")})
-		return
-	}
-
-	var jwtClaims models.UserClaim
-	if jwtErr := security.ParseJWT(jwtCookie.Value, &jwtClaims); jwtErr != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprint("Header: ", HandsAppCsrfToken, " is not present")})
-		return
-	}
-
-	if csrfToken != jwtClaims.CsrfToken {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Failed to verify double submit cookie"})
-		return
-	}
-
-	c.Set(GinKeyUser, jwtClaims)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -139,8 +139,8 @@ func main() {
 	r.POST("/v1/user/f", controllers.CreateUserWithFacebook)
 	r.POST("/v1/login", controllers.Login)
 	//r.GET("/v1/user/:ID", controllers.FindUser)
-	r.PATCH("/v1/user/:ID", controllers.CsrfMiddleware, controllers.PatchUser)
-	r.DELETE("/v1/user/:ID", controllers.CsrfMiddleware, controllers.DeleteUser)
+	r.PATCH("/v1/user/:ID", security.CsrfMiddleware, controllers.PatchUser)
+	r.DELETE("/v1/user/:ID", security.CsrfMiddleware, controllers.DeleteUser)
 
 	// Routes for locales
 	r.GET("/v1/locales", controllers.GetLocales)

--- a/src/security/security_test.go
+++ b/src/security/security_test.go
@@ -1,6 +1,12 @@
 package security
 
 import (
+	"API/controllers"
+	"API/models"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -69,6 +75,78 @@ func TestPasswordMatches(t *testing.T) {
 						t.Fatalf("PasswordMatches() = %v, want %v, (p: %v)", c.shouldMatch, matches, c.passedPassword)
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestCsrfMiddleware(t *testing.T) {
+	r := gin.New()
+	r.GET("/csrf", CsrfMiddleware)
+	dummyJWT, _ := CreateJWT(models.User{})
+
+	emptyRequest := httptest.NewRequest(http.MethodGet, "/csrf", nil)
+
+	justHeader := emptyRequest.Clone(emptyRequest.Context())
+	justHeader.Header.Set(controllers.HandsAppCsrfToken, dummyJWT.CsrfToken)
+
+	justCookie := emptyRequest.Clone(emptyRequest.Context())
+	justCookie.Header.Set("Cookie", fmt.Sprint(controllers.HandsAppSession, "=", dummyJWT.Token))
+
+	headerAndCookie := justHeader.Clone(justHeader.Context())
+	headerAndCookie.Header.Set("Cookie", fmt.Sprint(controllers.HandsAppSession, "=", dummyJWT.Token))
+
+	testCases := []struct {
+		Name     string
+		Expected int
+		*http.Request
+	}{
+		{"without authentication", http.StatusBadRequest, emptyRequest},
+		{"header is not present", http.StatusBadRequest, justCookie},
+		{"cookie is not present", http.StatusBadRequest, justHeader},
+		{"should pass when cookie and header are set", http.StatusOK, headerAndCookie},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, tc.Request)
+			if w.Code != tc.Expected {
+				t.Fatal("Expected: ", tc.Expected, "got: ", w.Code)
+			}
+		})
+	}
+}
+
+func TestApiKeyMiddleware(t *testing.T) {
+	r := gin.New()
+	r.GET("", ApiKeyMiddleware)
+
+	emptyRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	wrongApiKey := emptyRequest.Clone(emptyRequest.Context())
+	wrongApiKey.Header.Set("x-api-key", "not s3cret")
+
+	correctApiKey := emptyRequest.Clone(emptyRequest.Context())
+	correctApiKey.Header.Set("x-api-key", KEY)
+
+	testCases := []struct {
+		Name     string
+		Expected int
+		*http.Request
+	}{
+		{"without api key", http.StatusNotFound, emptyRequest},
+		{"wrong api key", http.StatusNotFound, wrongApiKey},
+		{"correct api key", http.StatusOK, correctApiKey},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, tc.Request)
+			if w.Code != tc.Expected {
+				t.Fatal("Expected: ", tc.Expected, "got: ", w.Code)
 			}
 		})
 	}


### PR DESCRIPTION
a new API key middleware was added (with unit tests)

the old method CheckKey keeps for compatibility,
but will be resolved in issue #23.

resolves #27